### PR TITLE
Use more specific warning for ambiguous slash

### DIFF
--- a/src/error/message.rs
+++ b/src/error/message.rs
@@ -52,6 +52,7 @@ pub enum DiagnosticMessage {
 
     // Lexer warnings
     AmbiguousTernaryOperator(String),
+    AmbiguousRegexp,
 
     // Parser errors
     ElseWithoutRescue,
@@ -157,6 +158,7 @@ impl DiagnosticMessage {
             Self::InvalidCvarName(name) => format!("`@@{}' is not allowed as a class variable name", *name as char),
             Self::UnknownRegexOptions(options) => format!("unknown regexp options - {}", options),
             Self::AmbiguousTernaryOperator(pre) => format!("`?' just followed by `{}' is interpreted as a conditional operator, put a space after `?'", pre),
+            Self::AmbiguousRegexp => "ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator".to_owned(),
             Self::UnterminatedUnicodeEscape => "unterminated Unicode escape".to_owned(),
             Self::EncodingError(err) => format!("encoding error: {}", err),
 

--- a/src/lexer/main.rs
+++ b/src/lexer/main.rs
@@ -1117,10 +1117,14 @@ impl Lexer {
     }
 
     pub(crate) fn arg_ambiguous(&mut self, c: u8, range: Range) -> bool {
-        self.warn(
-            DiagnosticMessage::AmbiguousFirstArgument { operator: c },
-            range,
-        );
+        if c == b'/' {
+            self.warn(DiagnosticMessage::AmbiguousRegexp, range);
+        } else {
+            self.warn(
+                DiagnosticMessage::AmbiguousFirstArgument { operator: c },
+                range,
+            );
+        }
         true
     }
 

--- a/tests/fixtures/parser/gen/test_send_plain_cmd_ambiguous_regexp_0
+++ b/tests/fixtures/parser/gen/test_send_plain_cmd_ambiguous_regexp_0
@@ -1,0 +1,4 @@
+--INPUT
+m /foo/
+--DIAGNOSTIC
+  ~ (warning) ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator

--- a/vendor/codegen/parser.rb
+++ b/vendor/codegen/parser.rb
@@ -193,6 +193,7 @@ module ParseHelperPatch
     :embedded_document => ->(*) { 'embedded document meets end of file' },
     :triple_dot_at_eol => ->(*) { '... at EOL, should be parenthesized?' },
     :ambiguous_prefix => ->(args, range) { "ambiguous first argument; put parentheses or a space even after `#{range.source}' operator" },
+    :ambiguous_regexp => ->(*) { "ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator" },
     :ambiguous_literal => ->(args, range) {
       op = range.source
       interpreted_as =


### PR DESCRIPTION
Backport of https://github.com/whitequark/parser/pull/768

This commit tracks upstream commit ruby/ruby@f5bb911.