### PR TITLE
bump rust-bison-skeleton; document new performance vs ripper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ onig = {version = "6", optional = true}
 
 [build-dependencies]
 lib-ruby-parser-nodes = {version = "0.7.0", optional = true}
-rust-bison-skeleton = {version = "0.11.0", optional = true}
+rust-bison-skeleton = {version = "0.12.0", optional = true}
 
 [dev-dependencies]
 clap = "3.0.0-beta.2"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ TLDR; it's fast, it's precise, and it has a beautiful interface.
 Comparison with `Ripper`/`RubyVM::AST`:
 1. It's based on MRI's `parse.y`, and so it returns **exactly** the same sequence of tokens.
 2. It's been tested on top 300 gems (by total downlads, that's about 3M LOC), `rubyspec` and `ruby/ruby` repos and there's no difference with `Ripper.lex`.
-3. It's as fast as `Ripper` (with `jemalloc`), both parse 3M LOC in 15s. That's ~200K LOC/s.
+3. It's ~2-3 times faster than `Ripper` (with `jemalloc`), Ripper parses 3.9M LOC in 16-17s, `lib-ruby-parser` does it 8-9s. That's ~450K LOC/s. And these benchmarks include IO that is roughly the same in Ruby and Rust. Without IO (i.e. for example with mmaped file from tmpfs) the difference is even more noticeable, however it's not what you are going to do anyway. I think it's valid to include IO into benchmarks.
 4. It has a much, much better interface. AST is strongly typed and well documented.
 5. It doesn't throw away information about tokens. All nodes have information about their source locations.
 
@@ -140,5 +140,6 @@ A pretty big codebase could be generated using a `download.rb` script:
 
 ```sh
 $ ruby gems/download.rb
-$ cargo run --release --all-features --example parse -- --no-output "gems/repos/**/*.rb"
+$ cargo build --release --all-features --example parse
+$ target/release/examples/parse --no-output "gems/repos/**/*.rb"
 ```

--- a/src/parse_value.rs
+++ b/src/parse_value.rs
@@ -621,3 +621,9 @@ impl ParseValue {
         Self::MatchPatternWithTrailingComma(Box::new(value))
     }
 }
+
+impl Default for ParseValue {
+    fn default() -> Self {
+        Self::Stolen
+    }
+}


### PR DESCRIPTION
New version of `rust-bison-skeleton` does way less allocations in `parse` method. Now `lib-ruby-parser` significantly outperforms Ripper:

```
repeat 10 time target/release/examples/parse --no-output 'gems/repos/**/*.rb'; repeat 10 time ruby -rripper -e "Dir['gems/repos/**/*.rb'].each { |f| Ripper.sexp(File.read(f)) }"
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  9.52s user 1.22s system 81% cpu 13.158 total
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  8.64s user 0.67s system 99% cpu 9.315 total
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  8.66s user 0.65s system 99% cpu 9.311 total
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  8.61s user 0.63s system 99% cpu 9.251 total
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  8.83s user 0.65s system 99% cpu 9.492 total
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  8.75s user 0.65s system 99% cpu 9.411 total
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  8.71s user 0.64s system 99% cpu 9.353 total
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  8.67s user 0.64s system 99% cpu 9.317 total
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  8.64s user 0.65s system 99% cpu 9.296 total
Done
target/release/examples/parse --no-output 'gems/repos/**/*.rb'  8.62s user 0.63s system 99% cpu 9.253 total
ruby -rripper -e   16.37s user 0.94s system 99% cpu 17.314 total
ruby -rripper -e   16.37s user 0.90s system 99% cpu 17.273 total
ruby -rripper -e   16.17s user 0.93s system 99% cpu 17.108 total
ruby -rripper -e   16.20s user 0.93s system 99% cpu 17.140 total
ruby -rripper -e   16.10s user 0.93s system 99% cpu 17.028 total
ruby -rripper -e   16.46s user 0.95s system 99% cpu 17.412 total
ruby -rripper -e   16.23s user 0.93s system 99% cpu 17.190 total
ruby -rripper -e   16.35s user 0.96s system 99% cpu 17.324 total
ruby -rripper -e   16.27s user 0.94s system 99% cpu 17.223 total
ruby -rripper -e   16.42s user 0.95s system 99% cpu 17.379 total
```