### PR TITLE
do not emit truncated parts of squiggly heredoc

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -402,12 +402,21 @@ impl Builder {
             .expect("dedent_level must be positive");
 
         let dedent_heredoc_parts = |parts: &mut Vec<Node>| {
-            for part in parts.iter_mut() {
+            let mut idx_to_drop = vec![];
+            for (idx, part) in parts.iter_mut().enumerate() {
                 match part {
-                    Node::Str(Str { value, .. }) => Self::dedent_string(value, dedent_level),
+                    Node::Str(Str { value, .. }) => {
+                        Self::dedent_string(value, dedent_level);
+                        if value.as_bytes().is_empty() {
+                            idx_to_drop.push(idx);
+                        }
+                    }
                     Node::Begin(_) => {}
                     _ => unreachable!("unsupported heredoc child {}", part.str_type()),
                 }
+            }
+            for idx in idx_to_drop.iter().rev() {
+                parts.remove(*idx);
             }
         };
 

--- a/tests/fixtures/parser/gen/test_parser_drops_truncated_parts_of_squiggly_heredoc_0
+++ b/tests/fixtures/parser/gen/test_parser_drops_truncated_parts_of_squiggly_heredoc_0
@@ -1,0 +1,16 @@
+--INPUT
+<<~HERE
+  #{}
+HERE
+--LOCATIONS
+        ~~~~~~ heredoc_body ()
+              ~~~~ heredoc_end ()
+~~~~~~~ expression ()
+          ~~ begin (part[0])
+            ~ end (part[0])
+          ~~~ expression (part[0])
+             ~ expression (part[1])
+--AST
+s(:dstr,
+  s(:begin),
+  s(:str, "\n"))


### PR DESCRIPTION
backport of https://github.com/whitequark/parser/commit/b87613d2b99733e1400f076675daf501c19ede93