### PR TITLE
do not drop optional else on reducing `case` from `case_body`

### DIFF
--- a/lib-ruby-parser/src/parser/parse.y
+++ b/lib-ruby-parser/src/parser/parse.y
@@ -4551,8 +4551,8 @@ opt_block_args_tail:
                     }
                 | case_body
                     {
-                        let CaseBody { when_bodies, .. } = $<CaseBody>1;
-                        $$ = Value::new_cases(Cases { when_bodies, opt_else: None });
+                        let CaseBody { when_bodies, opt_else } = $<CaseBody>1;
+                        $$ = Value::new_cases(Cases { when_bodies, opt_else });
                     }
                 ;
 

--- a/tests/fixtures/parser/manual/case_with_multipl_whens_and_else
+++ b/tests/fixtures/parser/manual/case_with_multipl_whens_and_else
@@ -1,0 +1,14 @@
+--INPUT
+case str
+when 'when1'
+when 'when2'
+else 'else-branch'
+end
+--AST
+s(:case,
+  s(:send, nil, "str"),
+  s(:when,
+    s(:str, "when1"), nil),
+  s(:when,
+    s(:str, "when2"), nil),
+  s(:str, "else-branch"))

--- a/tests/src/parser/manual.rs
+++ b/tests/src/parser/manual.rs
@@ -89,3 +89,4 @@ fixture_file!("fixtures/parser/manual", test_unterimated_heredoc_id_27_2);
 fixture_file!("fixtures/parser/manual", test_unterimated_heredoc_id_27_3);
 fixture_file!("fixtures/parser/manual", test_unterminated_embedded_doc_0);
 fixture_file!("fixtures/parser/manual", test_unterminated_embedded_doc_1);
+fixture_file!("fixtures/parser/manual", case_with_multipl_whens_and_else);


### PR DESCRIPTION
Fixes https://github.com/lib-ruby-parser/lib-ruby-parser/issues/65