### PR TITLE
Fix status badge markdown to follow the rename in github actions workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lib-ruby-parser
 
-[![test-rust](https://github.com/lib-ruby-parser/lib-ruby-parser/actions/workflows/test-rust.yml/badge.svg)](https://github.com/lib-ruby-parser/lib-ruby-parser/actions/workflows/test-rust.yml)
+[![test](https://github.com/lib-ruby-parser/lib-ruby-parser/actions/workflows/test.yml/badge.svg)](https://github.com/lib-ruby-parser/lib-ruby-parser/actions/workflows/test.yml)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 [![Crates.io](https://img.shields.io/crates/v/lib-ruby-parser?color=orange)](https://crates.io/crates/lib-ruby-parser)
 [![codecov](https://codecov.io/gh/lib-ruby-parser/lib-ruby-parser/branch/master/graph/badge.svg)](https://codecov.io/gh/lib-ruby-parser/lib-ruby-parser)


### PR DESCRIPTION
The status badge in README was missing the link and was not showing correctly.
<img width="270" alt="Screenshot 2024-02-11 at 1 16 22" src="https://github.com/lib-ruby-parser/lib-ruby-parser/assets/3862661/040d72f3-b161-4f87-87b4-3a532160816c">

Status badge in README should follow the GitHub actions workflow rename.